### PR TITLE
feat: removed mdns discovery from the integration

### DIFF
--- a/dependencies.cfg
+++ b/dependencies.cfg
@@ -3,4 +3,4 @@
 #   name: dependency name
 #   separator: colon + optional white space
 #   version: git branch or tag
-integrations.library: v0.4.0
+integrations.library: v0.4.1

--- a/dependencies.cfg
+++ b/dependencies.cfg
@@ -3,4 +3,4 @@
 #   name: dependency name
 #   separator: colon + optional white space
 #   version: git branch or tag
-integrations.library: v0.4.1
+integrations.library: v0.4.2

--- a/dock.json.in
+++ b/dock.json.in
@@ -33,5 +33,6 @@
       { \"name\" : \"app\", \"version\" : \"0.2.0\" },
       { \"name\" : \"remoteOS\", \"version\" : \"0.2.0\" }
   ],
-  \"mdns\": \"_yio-dock-api._tcp\"
+  \"mdns\": \"_yio-dock-api._tcp\",
+  \"setup_data\": $$CFG_SCHEMA
 }

--- a/dock.pro
+++ b/dock.pro
@@ -70,3 +70,7 @@ DISTFILES += \
     dock.json.in \
     version.txt.in \
     README.md
+
+
+# Add setup schema to metadata
+CFG_SCHEMA = "$$cat($$PWD/setup_schema.json)"

--- a/dock.pro
+++ b/dock.pro
@@ -73,4 +73,4 @@ DISTFILES += \
 
 
 # Add setup schema to metadata
-CFG_SCHEMA = "$$cat($$PWD/setup_schema.json)"
+CFG_SCHEMA = "$$cat($$PWD/setup-schema.json)"

--- a/setup-schema.json
+++ b/setup-schema.json
@@ -6,11 +6,6 @@
     "description": "Required data points to set up a YIO Dock integration.",
     "default": {},
     "additionalProperties": true,
-    "examples": [
-        {
-            "ip": ""
-        }
-    ],
     "required": [
         "ip"
     ],

--- a/setup_schema.json
+++ b/setup_schema.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "http://json-schema.org",
+    "$id": "http://yio-remote.com/yiodock.json",
+    "type": "object",
+    "title": "YIO Dock Integration Schema",
+    "description": "Required data points to set up a YIO Dock integration.",
+    "default": {},
+    "additionalProperties": true,
+    "examples": [
+        {
+            "ip": ""
+        }
+    ],
+    "required": [
+        "ip"
+    ],
+    "properties": {
+        "ip": {
+            "$id": "#/properties/ip",
+            "type": "string",
+            "title": "The ip schema",
+            "description": "The IP address or hostname of your YIO Dock.",
+            "default": "",
+            "examples": [
+                "192.168.100.2", "YIO-Dock-30AEA4D73C34.local"
+            ]
+        }
+    }
+}

--- a/src/dock.cpp
+++ b/src/dock.cpp
@@ -56,6 +56,8 @@ Dock::Dock(const QVariantMap &config, EntitiesInterface *entities, Notifications
         }
     }
 
+    m_url = QString("ws://").append(m_ip).append(":946");
+
     qRegisterMetaType<QAbstractSocket::SocketState>();
 
     m_entities = entities;
@@ -108,7 +110,7 @@ void Dock::onTextMessageReceived(const QString &message) {
     }
 
     if (type == "auth_ok") {
-        qCInfo(m_logCategory) << "Connection successful:" << friendlyName() << m_ip << m_id;
+        qCInfo(m_logCategory) << "Connection successful:" << friendlyName() << m_ip;
         setState(CONNECTED);
         m_heartbeatTimer->start();
     }
@@ -156,9 +158,8 @@ void Dock::onTimeout() {
         if (m_state != CONNECTING) {
             setState(CONNECTING);
         }
-        QString url = QString("ws://").append(m_ip).append(":946");
-        qCInfo(m_logCategory) << "Reconnection attempt" << m_tries + 1 << "to docking station:" << url;
-        m_webSocket->open(QUrl(url));
+        qCInfo(m_logCategory) << "Reconnection attempt" << m_tries + 1 << "to docking station:" << m_url;
+        m_webSocket->open(QUrl(m_url));
 
         m_tries++;
     }
@@ -181,9 +182,8 @@ void Dock::connect() {
         m_webSocket->close();
     }
 
-    QString url = QString("ws://").append(m_ip).append(":946");
-    qCDebug(m_logCategory) << "Connecting to docking station:" << url;
-    m_webSocket->open(QUrl(url));
+    qCDebug(m_logCategory) << "Connecting to docking station:" << m_url;
+    m_webSocket->open(QUrl(m_url));
 }
 
 void Dock::disconnect() {

--- a/src/dock.cpp
+++ b/src/dock.cpp
@@ -52,11 +52,11 @@ Dock::Dock(const QVariantMap &config, EntitiesInterface *entities, Notifications
     for (QVariantMap::const_iterator iter = config.begin(); iter != config.end(); ++iter) {
         if (iter.key() == Integration::OBJ_DATA) {
             QVariantMap map = iter.value().toMap();
-            m_ip            = map.value(Integration::KEY_DATA_IP).toString();
+            m_hostname      = map.value(Integration::KEY_DATA_IP).toString();
         }
     }
 
-    m_url = QString("ws://").append(m_ip).append(":946");
+    m_url = QString("ws://").append(m_hostname).append(":946");
 
     qRegisterMetaType<QAbstractSocket::SocketState>();
 
@@ -110,7 +110,7 @@ void Dock::onTextMessageReceived(const QString &message) {
     }
 
     if (type == "auth_ok") {
-        qCInfo(m_logCategory) << "Connection successful:" << friendlyName() << m_ip;
+        qCInfo(m_logCategory) << "Connection successful:" << friendlyName() << m_hostname;
         setState(CONNECTED);
         m_heartbeatTimer->start();
     }
@@ -141,7 +141,7 @@ void Dock::onTimeout() {
 
     if (m_tries == 3) {
         m_wsReconnectTimer->stop();
-        qCCritical(m_logCategory) << "Cannot connect to docking station: retried 3 times connecting to" << m_ip;
+        qCCritical(m_logCategory) << "Cannot connect to docking station: retried 3 times connecting to" << m_hostname;
 
         QObject *param = this;
         m_notifications->add(

--- a/src/dock.h
+++ b/src/dock.h
@@ -93,8 +93,8 @@ class Dock : public Integration {
     void        onHeartbeat();
     void        onHeartbeatTimeout();
 
-    QString     m_id;
     QString     m_ip;
+    QString     m_url;
     QString     m_token = "0";
     QWebSocket* m_webSocket;
     QTimer*     m_wsReconnectTimer;

--- a/src/dock.h
+++ b/src/dock.h
@@ -25,10 +25,8 @@
 #pragma once
 
 #include <QColor>
-#include <QLoggingCategory>
 #include <QObject>
 #include <QString>
-#include <QThread>
 #include <QTimer>
 #include <QVariant>
 #include <QtWebSockets/QWebSocket>
@@ -58,13 +56,10 @@ class DockPlugin : public Plugin {
     DockPlugin();
 
     // Plugin interface
-    /**
-     * @brief createIntegration Override default implementation in Plugin to allow MDNS discovery of multiple docks.
-     * @details The base class needs to be enhanced to handle non-configuration based integrations and multiple self
-     * discovered instances.
-     */
-    void create(const QVariantMap& config, EntitiesInterface* entities, NotificationsInterface* notifications,
-                YioAPIInterface* api, ConfigInterface* configObj) override;
+ protected:
+    Integration* createIntegration(const QVariantMap& config, EntitiesInterface* entities,
+                                   NotificationsInterface* notifications, YioAPIInterface* api,
+                                   ConfigInterface* configObj) override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -75,9 +70,8 @@ class Dock : public Integration {
     Q_OBJECT
 
  public:
-    explicit Dock(const QVariantMap& config, const QVariantMap& mdns, EntitiesInterface* entities,
-                  NotificationsInterface* notifications, YioAPIInterface* api, ConfigInterface* configObj,
-                  Plugin* plugin);
+    explicit Dock(const QVariantMap& config, EntitiesInterface* entities, NotificationsInterface* notifications,
+                  YioAPIInterface* api, ConfigInterface* configObj, Plugin* plugin);
 
     void sendCommand(const QString& type, const QString& entityId, int command, const QVariant& param) override;
 
@@ -101,7 +95,7 @@ class Dock : public Integration {
 
     QString     m_id;
     QString     m_ip;
-    QString     m_token;
+    QString     m_token = "0";
     QWebSocket* m_webSocket;
     QTimer*     m_wsReconnectTimer;
     int         m_tries;

--- a/src/dock.h
+++ b/src/dock.h
@@ -93,7 +93,7 @@ class Dock : public Integration {
     void        onHeartbeat();
     void        onHeartbeatTimeout();
 
-    QString     m_ip;
+    QString     m_hostname;
     QString     m_url;
     QString     m_token = "0";
     QWebSocket* m_webSocket;


### PR DESCRIPTION
The dock will be added to the config when setting up for the first time. After this, new docks can be added with the web configurator. The web configurator will do the mdns discovery.

There is no need to run a scan for new docks on the network, as it's highly unlikely that new docks will pop up every minute or so :)