### PR TITLE
Version as qmake argument for building as custom Buildroot package

### DIFF
--- a/dock.pro
+++ b/dock.pro
@@ -16,7 +16,7 @@ isEmpty(YIO_BUILD_VERSION) {
         GIT_BRANCH = "master"
     } else {
         # git hash as version = custom build
-        GIT_HASH = $$(YIO_BUILD_VERSION)
+        GIT_HASH = $$YIO_BUILD_VERSION
         GIT_BRANCH = ""
     }
 }

--- a/dock.pro
+++ b/dock.pro
@@ -2,10 +2,24 @@ TEMPLATE  = lib
 CONFIG   += plugin
 QT       += websockets core quick
 
-# Plugin VERSION
-GIT_HASH = "$$system(git log -1 --format="%H")"
-GIT_BRANCH = "$$system(git rev-parse --abbrev-ref HEAD)"
-GIT_VERSION = "$$system(git describe --match "v[0-9]*" --tags HEAD --always)"
+# === Version and build information ===========================================
+# If built in Buildroot use custom package version, otherwise Git
+GIT_VERSION = $$(YIO_INTEGRATION_DOCK_VERSION)
+isEmpty(GIT_VERSION) {
+    GIT_VERSION = "$$system(git describe --match "v[0-9]*" --tags HEAD --always)"
+    GIT_HASH = "$$system(git log -1 --format="%H")"
+    GIT_BRANCH = "$$system(git rev-parse --abbrev-ref HEAD)"
+} else {
+    contains(GIT_VERSION, "^v?(0|[1-9]\d*)\..*") {
+        # (simplified) version string = regular release
+        GIT_HASH = ""
+        GIT_BRANCH = "master"
+    } else {
+        # git hash as version = custom build
+        GIT_HASH = $$(YIO_INTEGRATION_DOCK_VERSION)
+        GIT_BRANCH = ""
+    }
+}
 DOCK_VERSION = $$replace(GIT_VERSION, v, "")
 DEFINES += PLUGIN_VERSION=\\\"$$DOCK_VERSION\\\"
 
@@ -16,6 +30,8 @@ win32 {
 } else {
     BUILDDATE=$$system(date +"%Y-%m-%dT%H:%M:%S")
 }
+# =============================================================================
+
 CONFIG(debug, debug|release) {
     DEBUG_BUILD = true
 } else {

--- a/dock.pro
+++ b/dock.pro
@@ -4,19 +4,19 @@ QT       += websockets core quick
 
 # === Version and build information ===========================================
 # If built in Buildroot use custom package version, otherwise Git
-GIT_VERSION = $$(YIO_INTEGRATION_DOCK_VERSION)
-isEmpty(GIT_VERSION) {
+isEmpty(YIO_BUILD_VERSION) {
     GIT_VERSION = "$$system(git describe --match "v[0-9]*" --tags HEAD --always)"
     GIT_HASH = "$$system(git log -1 --format="%H")"
     GIT_BRANCH = "$$system(git rev-parse --abbrev-ref HEAD)"
 } else {
+    GIT_VERSION = $$YIO_BUILD_VERSION
     contains(GIT_VERSION, "^v?(0|[1-9]\d*)\..*") {
         # (simplified) version string = regular release
         GIT_HASH = ""
         GIT_BRANCH = "master"
     } else {
         # git hash as version = custom build
-        GIT_HASH = $$(YIO_INTEGRATION_DOCK_VERSION)
+        GIT_HASH = $$(YIO_BUILD_VERSION)
         GIT_BRANCH = ""
     }
 }


### PR DESCRIPTION
When building with Buildroot the git version information from the integration plugin repository is not available.
Therefore use a QMake parameter `YIO_BUILD_VERSION` to provide the version from the Buildroot build.